### PR TITLE
fix: return ref instead of sha from the github action

### DIFF
--- a/.github/actions/github/action.yml
+++ b/.github/actions/github/action.yml
@@ -18,14 +18,12 @@ runs:
     - id: action
       env:
         ACTION_PATH: ${{ fromJSON(inputs.github).action_path }}
-        REPOSITORY: ${{ fromJSON(inputs.github).repository }}
-        SHA: ${{ fromJSON(inputs.github).sha }}
       run: |
         if [[ $ACTION_PATH == */_actions/* ]]; then
           echo "action_repository=$(echo ${ACTION_PATH#*/_actions/} | cut -d/ -f1-2)" >> $GITHUB_OUTPUT
           echo "action_ref=$(echo ${ACTION_PATH#*/_actions/} | cut -d/ -f3)" >> $GITHUB_OUTPUT
         else
           echo "action_repository=$GITHUB_REPOSITORY" >> $GITHUB_OUTPUT
-          echo "action_ref=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          echo "action_ref=$GITHUB_REF" >> $GITHUB_OUTPUT
         fi
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.1.5] - 2023-08-04
+### Fixed
+- Return ref instead of sha when running .github/actions/github action directly from the checkout
+
 ## [1.1.4] - 2023-03-10
 ### Fixed
 - Correctly validate if docker pull was successful


### PR DESCRIPTION
The issue that prompted this change is that GitHub.com stopped returning "merged pulls" refs by default when it is used as docker build context. However, I'd argue that this change makes sense anyway because if we say we're returning a ref, we might as well do that ;) 