### PR TITLE
feat: allow-exit-codes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test-build-args:
-    name: Test
+    name: Test Build Args
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -46,3 +46,19 @@ jobs:
           fi
 
           echo "all good"
+  test-failure:
+    name: Test Allow Exit Codes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        allow-exit-codes: ["0,42,1", "0,5,6,1,42", "0,*", "42", "*"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: build the container and run it
+        id: run
+        uses: ./
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          dockerfile: tests/Dockerfile.test-failure
+          allow-exit-codes: ${{ matrix.allow-exit-codes }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.1.8] - 2023-08-31
+### Added
+- Add `allow-exit-codes` parameter used when running the docker image
+
 ## [1.1.7] - 2023-08-04
 ### Added
 - Add `build-args` parameter used when building the docker image

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To use the action, add the following step to your GitHub Actions workflow:
 * `opts`: The Docker run options. Optional.
 * `args`: The Docker run args. Optional.
 * `build-args`: The Docker build args. Optional.
+* `allow-exit-codes`: A comma separated list of exit code allowed when running the container. Use * to allow all exit codes
 * `working-directory`: The Docker run working directory. Optional; defaults to `${{ github.workspace }}`.
 * `github-server-url`: The GitHub server URL. Optional; defaults to `${{ github.server_url }}`.
 * `docker-registry-url`: The Docker registry URL. Optional; defaults to `https://ghcr.io`.

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,11 @@ inputs:
     description: 'The docker registry URL'
     required: false
     default: 'https://ghcr.io'
+  allow-exit-codes:
+    description: 'A comma separated list of exit code allowed when running the container. Use * to allow all exit codes'
+    # see https://github.com/orgs/community/discussions/15452 for context.
+    required: false
+    default: '0'
 outputs:
   outputs:
     description: 'The outputs of the docker run step in JSON format'
@@ -93,6 +98,34 @@ runs:
       env:
         DOCKER_REGISTRY_URL: ${{ inputs.docker-registry-url }}
         IMAGE_TAG: ${{ steps.pull.outputs.image-tag }}
-      run: docker run --workdir "${PWD/"$GITHUB_WORKSPACE"/"/github/workspace"}" --rm --env-file <(env | grep -E '^(ACTIONS|GITHUB|INPUT|RUNNER)_') -e HOME -e CI -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "$GITHUB_WORKSPACE":"/github/workspace" ${{ inputs.opts }} "${IMAGE_TAG}" ${{ inputs.args }}
+        ALLOW_EXIT_CODES: ${{ inputs.allow-exit-codes }}
+      run: |
+        set +e
+        set +o pipefail
+
+        ALLOW_ALL=$(echo "$ALLOW_EXIT_CODES" | grep -q "\*"; echo $?)
+        EXIT_CODES=(${ALLOW_EXIT_CODES//,/ })
+
+        function docker_run() {
+          docker run --workdir "${PWD/"$GITHUB_WORKSPACE"/"/github/workspace"}" --rm --env-file <(env | grep -E '^(ACTIONS|GITHUB|INPUT|RUNNER)_') -e HOME -e CI -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "$GITHUB_WORKSPACE":"/github/workspace" ${{ inputs.opts }} "${IMAGE_TAG}" ${{ inputs.args }}
+          return $?
+        }
+
+        docker_run
+        EXIT_CODE=$?
+
+        if [[ $ALLOW_ALL -eq 0 ]]; then
+          echo "Allowing exit code $EXIT_CODE"
+          exit 0
+        fi
+
+        for ALLOWED_EXIT_CODE in "${EXIT_CODES[@]}"; do
+          if [[ "$EXIT_CODE" -eq "$ALLOWED_EXIT_CODE" ]]; then
+            echo "Allowing exit code $EXIT_CODE"
+            exit 0
+          fi
+        done
+
+        exit $EXIT_CODE
       working-directory: ${{ inputs.working-directory }}
       shell: bash

--- a/tests/Dockerfile.test-failure
+++ b/tests/Dockerfile.test-failure
@@ -1,0 +1,9 @@
+# a simple container that takes 3 args and generate a shell script that prints them
+FROM alpine:3.12.0
+
+RUN echo "#!/bin/sh" > /script.sh
+RUN echo "exit 42" >> /script.sh
+
+RUN chmod +x /script.sh
+
+ENTRYPOINT ["/script.sh"]


### PR DESCRIPTION
Adds an option to allow failing code.

Related: https://github.com/orgs/community/discussions/15452

Supports https://github.com/ipfs/gateway-conformance/issues/123, https://github.com/ipfs/gateway-conformance/issues/147, and https://github.com/ipfs/public-gateway-checker/pull/450.

- double checked: https://github.com/laurentsenta/docker-container-action/actions/runs/6035404011. see the `51` and `0` (defaults) cases failing as expected.